### PR TITLE
fix: 优化流式更新时的日志输出，避免控制台刷屏

### DIFF
--- a/js/processing/formula_post_processor.js
+++ b/js/processing/formula_post_processor.js
@@ -319,7 +319,11 @@
         processNode(rootElement);
 
         const duration = performance.now() - startTime;
-        console.log(`[FormulaPostProcessor] 处理完成: 渲染 ${processedCount} 个公式, 删除 ${removedCount} 个错误块, 耗时 ${duration.toFixed(2)}ms`);
+
+        // Phase 3.5: 只在有实际处理时才输出日志，避免流式更新时刷屏
+        if (processedCount > 0 || removedCount > 0) {
+            console.log(`[FormulaPostProcessor] 处理完成: 渲染 ${processedCount} 个公式, 删除 ${removedCount} 个错误块, 耗时 ${duration.toFixed(2)}ms`);
+        }
 
         return { processedCount, removedCount };
     }

--- a/js/processing/markdown_processor_ast.js
+++ b/js/processing/markdown_processor_ast.js
@@ -16,6 +16,9 @@
     // 缓存系统
     const renderCache = new Map();
 
+    // Phase 3.5: 记录已经警告过的图片路径，避免流式更新时重复警告
+    const _warnedImages = new Set();
+
     // 性能指标
     const metrics = {
         cacheHits: 0,
@@ -561,7 +564,11 @@
                 }
             }
 
-            console.warn('[MarkdownProcessorAST] Image not found:', path);
+            // Phase 3.5: 只警告一次，避免流式更新时重复输出
+            if (!_warnedImages.has(path)) {
+                console.warn('[MarkdownProcessorAST] Image not found:', path);
+                _warnedImages.add(path);
+            }
             return match;
         });
 

--- a/js/processing/markdown_processor_integration.js
+++ b/js/processing/markdown_processor_integration.js
@@ -5,6 +5,9 @@
 (function(global) {
     'use strict';
 
+    // Phase 3.5: 警告标志位，避免流式更新时重复输出
+    let _rendererWarningShown = false;
+
     /**
      * 智能渲染函数：自动选择最佳渲染方式
      * @param {string} markdown - Markdown 文本
@@ -41,7 +44,11 @@
         } else if (isRenderer) {
             // 传入了 marked.Renderer（旧版方式）
             // 在 AST 模式下，renderer 会被忽略，应该使用后处理方式
-            console.warn('[Integration] 检测到 marked.Renderer，但 AST 模式不支持。请使用后处理或迁移到注释数组。');
+            // Phase 3.5: 只输出一次警告，避免流式更新时刷屏
+            if (!_rendererWarningShown) {
+                console.warn('[Integration] 检测到 marked.Renderer，但 AST 模式不支持。请使用后处理或迁移到注释数组。');
+                _rendererWarningShown = true;
+            }
             return global.MarkdownProcessorAST.render(markdown, images);
         } else {
             // 没有注释或空数组


### PR DESCRIPTION
## 问题
流式更新频繁触发（每 0.5 秒），导致以下日志刷屏：
1. [FormulaPostProcessor] 处理完成 - 每次都输出，即使没有公式
2. [Integration] 检测到 marked.Renderer - 每次都输出相同警告
3. [MarkdownProcessorAST] Image not found - 同一图片反复警告


## 修复

### 1. FormulaPostProcessor (formula_post_processor.js:322)
- 只在有实际处理时才输出日志
- 条件：processedCount > 0 || removedCount > 0

### 2. Renderer 兼容性警告 (markdown_processor_integration.js:44)
- 添加 _rendererWarningShown 标志位
- 只输出一次警告，避免重复

### 3. 图片找不到警告 (markdown_processor_ast.js:564)
- 添加 _warnedImages Set
- 同一图片路径只警告一次

## 效果
- ✅ 控制台清爽，不刷屏
- ✅ 有意义的日志仍然会输出
- ✅ 性能优化不影响调试
- ✅ 警告信息不会丢失，只是去重