### PR TITLE
fix: 修复智谱 API 模型检测路径重复问题

### DIFF
--- a/js/ui/ui.js
+++ b/js/ui/ui.js
@@ -2173,11 +2173,17 @@ document.addEventListener('DOMContentLoaded', function() {
             let successfulKey = null;
 
             const requestFormat = site.requestFormat || 'openai';
+            const endpointMode = site.endpointMode || 'auto';
 
             for (const key of validKeys) {
                 try {
                     showNotification(`正在尝试使用Key (${key.value.substring(0, 4)}...) 检测模型`, 'info');
-                    modelsDetected = await window.modelDetector.detectModelsForSite(site.apiBaseUrl, key.value, requestFormat);
+                    modelsDetected = await window.modelDetector.detectModelsForSite(
+                        site.apiBaseUrl,
+                        key.value,
+                        requestFormat,
+                        endpointMode
+                    );
 
                     if (modelsDetected && modelsDetected.length > 0) {
                         successfulKey = key;


### PR DESCRIPTION
问题描述：
- 智谱 API 模型检测失败，返回 404 错误
- 请求路径错误地变成了 /v4/v1/models（/v1 重复）
- 正确路径应该是 /v4/models

解决方案：
- 在调用 detectModelsForSite 时传递 endpointMode 参数
- endpointMode 从站点配置中读取，默认为 'auto'
- 确保模型检测器能正确处理不同 API 的端点模式

修复后效果：
- 智谱 API 可以正常检测到可用模型
- 不再出现路径重复导致的 404 错误